### PR TITLE
Use JDK 8 instead of 17 for 1.16.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,24 +16,24 @@ jobs:
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
 
-      - name: Set up JDK 17
-        uses: actions/setup-java@v3
+      - name: Set up JDK 8
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
-          java-version: 17
+          java-version: 8
           check-latest: true
 
       - name: Build using Gradle
         run: ./gradlew build
 
       - name: Upload Fabric artifacts to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Fabric-Artifacts
           path: fabric/build/libs/
 
       - name: Upload Forge artifacts to GitHub
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: Forge-Artifacts
           path: forge/build/libs/

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,9 +1,9 @@
-# Sets up the GitPod shell using the Java 17 workspace which then
+# Sets up the GitPod shell using the Java 8 workspace which then
 # also sets SDKMAN for GitPod as finalization.
 
-FROM gitpod/workspace-java-17
+FROM gitpod/workspace-java-8
 USER gitpod
 
 SHELL ["/bin/bash", "-c"]
 
-RUN source ~/.sdkman/bin/sdkman-init.sh && sdk install java 17.0.10-tem && sdk use java 17.0.10-tem
+RUN source ~/.sdkman/bin/sdkman-init.sh && sdk install 8.0.402-tem && sdk use java 8.0.402-tem

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,9 +1,9 @@
-# Sets up the GitPod shell using the Java 8 workspace which then
-# also sets SDKMAN for GitPod as finalization.
+# Sets up the GitPod shell using gitpod's base workspace which then
+# also sets up JDK 8 using SDKMAN for GitPod as finalization.
 
-FROM gitpod/workspace-java-8
+FROM gitpod/workspace-base
 USER gitpod
 
 SHELL ["/bin/bash", "-c"]
 
-RUN source ~/.sdkman/bin/sdkman-init.sh && sdk install 8.0.402-tem && sdk use java 8.0.402-tem
+RUN curl -s "https://get.sdkman.io" | bash && source ~/.sdkman/bin/sdkman-init.sh && sdk install java 8.0.402-tem && sdk use java 8.0.402-tem

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,7 +1,7 @@
-# Deploys the latest stable JDK 17 available and sets it to default without having to manually specify it here,
+# Deploys the latest stable JDK 8 available and sets it to default without having to manually specify it here,
 # Which includes using temurin as the distribution.
 before_install:
   - curl -s "https://get.sdkman.io" | bash
   - source ~/.sdkman/bin/sdkman-init.sh
-  - sdk install java 17.0.10-tem
-  - sdk use java 17.0.10-tem
+  - sdk install java 8.0.402-tem
+  - sdk use java 8.0.402-tem


### PR DESCRIPTION
Title says it, Also fixes GitPod so that it properly installs java for us in base variant of their workspace.